### PR TITLE
docs: Edit Example on README so that it won't cause ReferenceError

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,27 @@ NOTE: [`svelte-disable-preload`](https://www.npmjs.com/package/svelte-disable-pr
 
 ```svelte
 <script lang="ts">
-  import { panzoom, type Options } from 'svelte-pan-zoom'
+import { panzoom, type Options, type Point } from '$lib'
 
-  export let image: CanvasImageSource
+	const promise = new Promise<Options>(resolve => {
+		const image = new Image()
 
-  function render(ctx: CanvasRenderingContext2D, t: number) {
-    ctx.drawImage(image, 0, 0)
-  }
+		image.onload = () =>
+			resolve({
+				width: image.width,
+				height: image.height,
+				render,
+			})
+		image.src = './svelte-kit-machine.webp'
+
+		function render(ctx: CanvasRenderingContext2D, _t: number, _focus: Point) {
+			ctx.drawImage(image, 0, 0)
+		}
+	})
 </script>
 
 {#await promise then options}
-  <canvas use:panzoom={{ render, width: image.width, height: image.height }} />
+	<canvas use:panzoom={options} />
 {/await}
 
 <style>


### PR DESCRIPTION
Hello, 
This PR addresses the following ReferenceError, which happens when following the example on the README.

Thanks!

<img width="197" alt="스크린샷 2024-01-15 오전 11 43 01" src="https://github.com/CaptainCodeman/svelte-pan-zoom/assets/82362278/7d9ebd01-56e5-4003-9e36-d84cec1499f3">

