### PR TITLE
Fix issue where pan position resets when canvas visibility is toggled

### DIFF
--- a/src/lib/panzoom.ts
+++ b/src/lib/panzoom.ts
@@ -87,6 +87,11 @@ export function panzoom(canvas: HTMLCanvasElement, options: Options) {
 
   const preloadAction = disablePreload(canvas)
   const resizeAction = resize(canvas, entry => {
+    // Do not resize if canvas is hidden
+    if(canvas.clientWidth === 0 && canvas.clientHeight === 0){
+      return
+    }
+    
     const rect = entry.contentRect
     const prev = toImageSpace({ x: view_width / 2, y: view_height / 2 })
     const transform = ctx.getTransform()


### PR DESCRIPTION
Currently, when the canvas visibility is toggled (e.g., display: none or visibility: hidden), the zoom or pan position is lost, resulting in an unexpected user experience. This MR addresses that bug. 